### PR TITLE
FEAT: Publish to DockerHub on build

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -1,0 +1,38 @@
+name: Publish Docker image to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/localizationdemo-api
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src/LocalizationDemo.Api
+          file: ./src/LocalizationDemo.Api/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/localizationdemo-api:latest
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- [x] A GitHub Actions workflow exists (e.g.`.github/workflows/publish-dockerhub.yaml`)
- [x] The workflow builds the Docker image from the repository’s Dockerfile
- [x] The workflow authenticates to Docker Hub using repository secrets (`DOCKERHUB_USERNAME`, `DOCKERHUB_PASSWORD`)
- [x] The image is tagged appropriately (e.g., with the commit SHA or release version)
- [x] The image is pushed to the correct Docker Hub repository

Resolves #7 